### PR TITLE
Update 07_quicksort.md

### DIFF
--- a/clrs/07_quicksort.md
+++ b/clrs/07_quicksort.md
@@ -144,15 +144,20 @@ TODO
 ##### 7-4 Stack depth for quicksort
 a. last line of while loop is equivalent to call TAIL-RECURSIVE-QUICKSORT(A, q+1, r)   
 
-b. Array is in decreasing order.
+b. Array is already sorted. Thus each time q = r.
 
-c. 
+c. Always recurse into the smaller subarray.
 
 	TAIL-RECURSIVE-QUICKSORT(A, p, r)
 		while p < r
-			q = RANDOMIZED-PARTITION(A, p, r)
-			TAIL-RECURSIVE-QUICKSORT(A, p, q-1)
-			p = q + 1
+			q = PARTITION(A, p, r)
+			if (q < (p + r)/2) {
+				TAIL-RECURSIVE-QUICKSORT(A, p, q-1)
+				p = q + 1
+			} else {
+				TAIL-RECURSIVE-QUICKSORT(A, q+1, r)
+				r = q - 1
+			}
 			
 ##### 7-5 Median-of-3 partition
 a. Pr(x less than i) * Pr(x larger than i)


### PR DESCRIPTION
7.4 b: If array is reverse order q = p + 1, thus recursive call returns immediately, the maximum stack depth is 1.
7.4 c: randomized partition can not improve the worst-case run-time.

Plz refer to http://mypathtothe4.blogspot.com/2013/02/lesson-2-variations-on-quicksort-tail.html